### PR TITLE
调整滚轮交互：时间轴区域居中缩放，左侧保留滚屏

### DIFF
--- a/app.js
+++ b/app.js
@@ -2646,15 +2646,13 @@ const DEFAULT_CSV_SAMPLE = `# time,title（两列；layer 由文件名决定，�
   }
 
   function handleWheel(event) {
-    if (!event.shiftKey && !event.ctrlKey && !event.metaKey) return;
-    event.preventDefault();
     const rect = ui.canvas.getBoundingClientRect();
-    const mouseX = event.clientX - rect.left;
     const centerX = rect.width / 2;
-    const pivotX = event.shiftKey ? centerX : mouseX;
-    const speed = event.ctrlKey || event.metaKey ? 4 : 1;
-    const factor = Math.pow(1.0015, -event.deltaY * speed);
-    applyZoom(pivotX, factor);
+    const mouseX = event.clientX - rect.left;
+    if (mouseX < state.leftPad) return;
+    event.preventDefault();
+    const factor = Math.pow(1.0015, -event.deltaY);
+    applyZoom(centerX, factor);
   }
 
   function showLayerMenu(x, y, layer) {


### PR DESCRIPTION
### Motivation
- 用户反馈当前滚轮交互不直观，需要在时间轴区域直接缩放并以可视中心为锚点。 
- 在时间轴之外（如左侧图层文字列）滚轮应保留为页面滚屏以免妨碍其它界面操作。 

### Description
- 修改 `app.js` 中的 `handleWheel` 函数以移除对 `Shift/Ctrl/Cmd` 的依赖，滚轮在时间轴区域直接触发缩放。 
- 在 `handleWheel` 中新增对鼠标横向位置的判断：当 `mouseX < state.leftPad` 时直接返回，从而保留默认滚动行为。 
- 将缩放锚点统一设为画布中心 `centerX`，并取消 Ctrl/Cmd 的加速倍率，统一使用 `Math.pow(1.0015, -event.deltaY)` 计算缩放因子。 
- 仅变更滚轮交互逻辑，未修改拖拽、图层重排等其它鼠标处理代码。 

### Testing
- 未新增或运行自动化测试；仓库当前未包含单元/集成测试脚本，故未执行测试套件。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13dfd5e4b08332a703051217437ed4)