### PR TITLE
Wheel scroll: zoom only when over timeline canvas and allow layer-area scrolling

### DIFF
--- a/app.js
+++ b/app.js
@@ -2646,15 +2646,17 @@ const DEFAULT_CSV_SAMPLE = `# time,title（两列；layer 由文件名决定，�
   }
 
   function handleWheel(event) {
-    if (!event.shiftKey && !event.ctrlKey && !event.metaKey) return;
-    event.preventDefault();
+    if (!ui.canvas) return;
     const rect = ui.canvas.getBoundingClientRect();
-    const mouseX = event.clientX - rect.left;
+    const insideCanvas = event.clientX >= rect.left && event.clientX <= rect.right
+      && event.clientY >= rect.top && event.clientY <= rect.bottom;
+    if (!insideCanvas) return;
     const centerX = rect.width / 2;
-    const pivotX = event.shiftKey ? centerX : mouseX;
-    const speed = event.ctrlKey || event.metaKey ? 4 : 1;
-    const factor = Math.pow(1.0015, -event.deltaY * speed);
-    applyZoom(pivotX, factor);
+    const mouseX = event.clientX - rect.left;
+    if (mouseX < state.leftPad) return;
+    event.preventDefault();
+    const factor = Math.pow(1.0015, -event.deltaY);
+    applyZoom(centerX, factor);
   }
 
   function showLayerMenu(x, y, layer) {

--- a/index.html
+++ b/index.html
@@ -112,8 +112,8 @@
             <li>左栏右边缘把手：折叠 / 展开参考区</li>
             <li>页面上下滚动：浏览更多图层</li>
             <li><span class="kbd">拖拽</span> 时间轴：左右平移</li>
-            <li><span class="kbd">Shift + 滚轮</span>：围绕中心缩放</li>
-            <li><span class="kbd">Ctrl/Cmd + 滚轮</span>：加速缩放</li>
+            <li><span class="kbd">滚轮</span>（时间轴区域内）：围绕中心缩放</li>
+            <li><span class="kbd">滚轮</span>（左侧图层名区域）：页面上下滚动</li>
             <li>顶部“范围预设”：快速切到人类史 / 地质史 / 宇宙史</li>
             <li>在左侧图层名区域按住拖动：调整图层顺序</li>
             <li><span class="kbd">右键</span> 图层名：重命名、隐藏、改颜色、删除</li>


### PR DESCRIPTION
### Motivation

- Simplify and make wheel behavior more intuitive by restricting zoom to the timeline drawing area and restore normal page scrolling when the pointer is over the left layer list.
- Remove modifier-key gating and accelerated zoom so plain wheel inside the timeline produces zoom while outside it (or in the left pad) does not trigger zoom.

### Description

- Guard `handleWheel` with `if (!ui.canvas) return;` and check the mouse is inside the canvas rect before proceeding.  
- Skip zoom when the pointer is in the left layer name area by returning if `mouseX < state.leftPad`, and treat wheel over the layer area as normal page scroll.  
- Always center zoom on the canvas (`applyZoom(centerX, factor)`) and compute `factor` without modifier-based speed, and call `event.preventDefault()` only when zooming.  
- Update UI help text in `index.html` to document that wheel inside the timeline centers zoom and that wheel over the left layer name area scrolls the page.

### Testing

- Ran `npm test` and unit tests completed successfully.  
- Performed a development build with `npm run build` which succeeded.  
- Executed automated linting via `npm run lint` and there were no lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13dfd5e4b08332a703051217437ed4)