### PR TITLE
Make mouse-wheel zoom operate under cursor and allow scrolling in left layer area; update help text

### DIFF
--- a/app.js
+++ b/app.js
@@ -2646,15 +2646,16 @@ const DEFAULT_CSV_SAMPLE = `# time,title（两列；layer 由文件名决定，�
   }
 
   function handleWheel(event) {
-    if (!event.shiftKey && !event.ctrlKey && !event.metaKey) return;
-    event.preventDefault();
+    if (!ui.canvas) return;
     const rect = ui.canvas.getBoundingClientRect();
+    const insideCanvas = event.clientX >= rect.left && event.clientX <= rect.right
+      && event.clientY >= rect.top && event.clientY <= rect.bottom;
+    if (!insideCanvas) return;
     const mouseX = event.clientX - rect.left;
-    const centerX = rect.width / 2;
-    const pivotX = event.shiftKey ? centerX : mouseX;
-    const speed = event.ctrlKey || event.metaKey ? 4 : 1;
-    const factor = Math.pow(1.0015, -event.deltaY * speed);
-    applyZoom(pivotX, factor);
+    if (mouseX < state.leftPad) return;
+    event.preventDefault();
+    const factor = Math.pow(1.0015, -event.deltaY);
+    applyZoom(mouseX, factor);
   }
 
   function showLayerMenu(x, y, layer) {

--- a/index.html
+++ b/index.html
@@ -112,8 +112,8 @@
             <li>左栏右边缘把手：折叠 / 展开参考区</li>
             <li>页面上下滚动：浏览更多图层</li>
             <li><span class="kbd">拖拽</span> 时间轴：左右平移</li>
-            <li><span class="kbd">Shift + 滚轮</span>：围绕中心缩放</li>
-            <li><span class="kbd">Ctrl/Cmd + 滚轮</span>：加速缩放</li>
+            <li><span class="kbd">滚轮</span>（时间轴区域内）：围绕鼠标位置缩放</li>
+            <li><span class="kbd">滚轮</span>（左侧图层名区域）：页面上下滚动</li>
             <li>顶部“范围预设”：快速切到人类史 / 地质史 / 宇宙史</li>
             <li>在左侧图层名区域按住拖动：调整图层顺序</li>
             <li><span class="kbd">右键</span> 图层名：重命名、隐藏、改颜色、删除</li>


### PR DESCRIPTION
### Motivation

- Make zooming with the mouse wheel more intuitive by zooming around the cursor when inside the timeline canvas and avoid intercepting wheel scroll over the left layer list so the page can scroll naturally.

### Description

- Change `handleWheel` in `app.js` to bail out if `ui.canvas` is missing and to compute the canvas `getBoundingClientRect()` to ensure the wheel event is inside the canvas before handling.
- Only handle the wheel when the pointer is inside the canvas and `mouseX >= state.leftPad`, allowing wheel events on the left layer name area to perform normal page scrolling; call `event.preventDefault()` only when zooming.
- Simplify zoom behavior by always using the cursor X as pivot and removing the modifier-key gating and separate speed multiplier, using `applyZoom(mouseX, factor)` with a stable factor calculation.
- Update the user hint lines in `index.html` to describe the new wheel behavior: wheel zooms around the mouse in the timeline area while the left layer name area scrolls the page.

### Testing

- Ran the project's automated test suite using `npm test` and the linter `npm run lint`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13dfd5e4b08332a703051217437ed4)