### PR TITLE
移动端兼容：增强触控交互与响应式布局

### DIFF
--- a/app.js
+++ b/app.js
@@ -52,6 +52,13 @@ const DEFAULT_CSV_SAMPLE = `# time,title（两列；layer 由文件名决定，�
   const SECONDS_PER_DAY = 24 * SECONDS_PER_HOUR;
   const EVENT_TOOLTIP_OFFSET = 14;
   const EVENT_HIT_MIN_WIDTH = 10;
+  const MOBILE_BREAKPOINT = 720;
+  const DESKTOP_LEFT_PAD = 80;
+  const MOBILE_LEFT_PAD = 72;
+  const DESKTOP_RIGHT_PAD = 20;
+  const MOBILE_RIGHT_PAD = 12;
+  const DESKTOP_LANE_HEIGHT = 26;
+  const MOBILE_LANE_HEIGHT = 30;
   const LAYER_COLOR_PRESETS = [
     '#3ea6ff', '#56c271', '#f7b538', '#ff7a59', '#ff5d8f', '#b27cff',
     '#27c1b8', '#7a8cff', '#9ccc65', '#d4a017', '#c86bfa', '#ef476f',
@@ -891,6 +898,18 @@ const DEFAULT_CSV_SAMPLE = `# time,title（两列；layer 由文件名决定，�
   };
 
   const pointer = { isPanning: false, lastX: 0, lastY: 0 };
+  const touchState = {
+    mode: null,
+    startX: 0,
+    startY: 0,
+    lastX: 0,
+    lastY: 0,
+    hasMoved: false,
+    longPressTimer: null,
+    layer: null,
+    pinchDistance: 0,
+    pinchCenterX: 0,
+  };
 
   function init() {
     if (!cacheDomHandles()) {
@@ -913,6 +932,7 @@ const DEFAULT_CSV_SAMPLE = `# time,title（两列；layer 由文件名决定，�
     initBackgroundSelector();
     buildColorSwatches();
     window.addEventListener('resize', resizeCanvas);
+    window.visualViewport?.addEventListener('resize', resizeCanvas);
     resizeCanvas();
     loadCsvTextarea();
     runSelfTests();
@@ -1569,12 +1589,30 @@ const DEFAULT_CSV_SAMPLE = `# time,title（两列；layer 由文件名决定，�
     return total;
   }
 
+  function isMobileViewport(width = window.innerWidth) {
+    return width <= MOBILE_BREAKPOINT;
+  }
+
+  function syncResponsiveCanvasMetrics() {
+    const mobile = isMobileViewport();
+    state.leftPad = mobile ? MOBILE_LEFT_PAD : DESKTOP_LEFT_PAD;
+    state.rightPad = mobile ? MOBILE_RIGHT_PAD : DESKTOP_RIGHT_PAD;
+    state.laneHeight = mobile ? MOBILE_LANE_HEIGHT : DESKTOP_LANE_HEIGHT;
+  }
+
   function getMinimumCanvasHeight() {
     const headerHeight = document.querySelector('header')?.offsetHeight || 0;
-    return Math.max(480, window.innerHeight - headerHeight);
+    const visualHeight = window.visualViewport?.height || window.innerHeight;
+    const mobile = isMobileViewport();
+    const fallback = mobile ? 420 : 480;
+    const viewportShare = mobile ? visualHeight * 0.72 : visualHeight - headerHeight;
+    return Math.max(fallback, viewportShare);
   }
 
   function syncCanvasSize() {
+    syncResponsiveCanvasMetrics();
+    const headerHeight = document.querySelector('header')?.offsetHeight || 0;
+    document.documentElement.style.setProperty('--mobile-header-height', `${headerHeight}px`);
     const targetHeight = Math.max(getMinimumCanvasHeight(), getContentHeight());
     ui.canvas.style.height = `${targetHeight}px`;
     const rect = ui.canvas.getBoundingClientRect();
@@ -2698,6 +2736,10 @@ const DEFAULT_CSV_SAMPLE = `# time,title（两列；layer 由文件名决定，�
     window.addEventListener('mousemove', handleMouseMove);
     ui.canvas.addEventListener('mouseleave', handleMouseLeave);
     ui.canvas.addEventListener('wheel', handleWheel, { passive: false });
+    ui.canvas.addEventListener('touchstart', handleTouchStart, { passive: false });
+    ui.canvas.addEventListener('touchmove', handleTouchMove, { passive: false });
+    ui.canvas.addEventListener('touchend', handleTouchEnd, { passive: false });
+    ui.canvas.addEventListener('touchcancel', handleTouchCancel);
     ui.canvas.addEventListener('dblclick', resetView);
     ui.canvas.addEventListener('contextmenu', handleContextMenu);
 
@@ -2942,6 +2984,170 @@ const DEFAULT_CSV_SAMPLE = `# time,title（两列；layer 由文件名决定，�
     event.preventDefault();
     const factor = Math.pow(1.0015, -event.deltaY);
     applyZoom(mouseX, factor);
+  }
+
+  function getTouchPoint(touch) {
+    const rect = ui.canvas.getBoundingClientRect();
+    return {
+      clientX: touch.clientX,
+      clientY: touch.clientY,
+      x: touch.clientX - rect.left,
+      y: touch.clientY - rect.top,
+    };
+  }
+
+  function getTouchDistance(touchA, touchB) {
+    return Math.hypot(touchA.clientX - touchB.clientX, touchA.clientY - touchB.clientY);
+  }
+
+  function getTouchCenter(touchA, touchB) {
+    const rect = ui.canvas.getBoundingClientRect();
+    return {
+      clientX: (touchA.clientX + touchB.clientX) / 2,
+      clientY: (touchA.clientY + touchB.clientY) / 2,
+      x: (touchA.clientX + touchB.clientX) / 2 - rect.left,
+      y: (touchA.clientY + touchB.clientY) / 2 - rect.top,
+    };
+  }
+
+  function clearTouchLongPress() {
+    if (!touchState.longPressTimer) return;
+    window.clearTimeout(touchState.longPressTimer);
+    touchState.longPressTimer = null;
+  }
+
+  function resetTouchState() {
+    clearTouchLongPress();
+    touchState.mode = null;
+    touchState.layer = null;
+    touchState.hasMoved = false;
+    touchState.pinchDistance = 0;
+    touchState.pinchCenterX = 0;
+  }
+
+  function findLayerAtCanvasPoint(x, y) {
+    if (x >= state.leftPad) return null;
+    for (const [layer, box] of state.layerRects) {
+      if (y >= box.top && y <= box.top + box.height) return layer;
+    }
+    return null;
+  }
+
+  function handleTouchStart(event) {
+    hideLayerMenu();
+    hideColorMenu();
+    hideEventTooltip();
+    pointer.isPanning = false;
+
+    if (event.touches.length === 2) {
+      clearTouchLongPress();
+      const [first, second] = event.touches;
+      const center = getTouchCenter(first, second);
+      touchState.mode = 'pinch';
+      touchState.pinchDistance = getTouchDistance(first, second);
+      touchState.pinchCenterX = center.x;
+      event.preventDefault();
+      return;
+    }
+
+    if (event.touches.length !== 1) return;
+    const point = getTouchPoint(event.touches[0]);
+    touchState.mode = 'pending';
+    touchState.startX = point.x;
+    touchState.startY = point.y;
+    touchState.lastX = point.x;
+    touchState.lastY = point.y;
+    touchState.hasMoved = false;
+    touchState.layer = findLayerAtCanvasPoint(point.x, point.y);
+
+    if (touchState.layer) {
+      touchState.longPressTimer = window.setTimeout(() => {
+        if (touchState.mode !== 'pending' || touchState.hasMoved || !touchState.layer) return;
+        showLayerMenu(point.clientX, point.clientY, touchState.layer);
+        resetTouchState();
+      }, 520);
+    }
+  }
+
+  function handleTouchMove(event) {
+    if (event.touches.length === 2) {
+      const [first, second] = event.touches;
+      const center = getTouchCenter(first, second);
+      const nextDistance = getTouchDistance(first, second);
+      if (touchState.mode !== 'pinch') {
+        clearTouchLongPress();
+        touchState.mode = 'pinch';
+        touchState.pinchDistance = nextDistance;
+        touchState.pinchCenterX = center.x;
+        event.preventDefault();
+        return;
+      }
+      if (touchState.pinchDistance > 0 && nextDistance > 0) {
+        const panDx = center.x - touchState.pinchCenterX;
+        state.viewStart -= panDx / state.pxPerYear;
+        applyZoom(center.x, nextDistance / touchState.pinchDistance);
+      }
+      touchState.pinchDistance = nextDistance;
+      touchState.pinchCenterX = center.x;
+      event.preventDefault();
+      return;
+    }
+
+    if (event.touches.length !== 1 || !touchState.mode) return;
+    const point = getTouchPoint(event.touches[0]);
+    const totalDx = point.x - touchState.startX;
+    const totalDy = point.y - touchState.startY;
+
+    if (Math.hypot(totalDx, totalDy) > 8) {
+      touchState.hasMoved = true;
+      clearTouchLongPress();
+    }
+
+    if (touchState.mode === 'pending') {
+      if (Math.abs(totalDx) > 8 && Math.abs(totalDx) > Math.abs(totalDy)) {
+        touchState.mode = 'pan';
+      } else if (Math.abs(totalDy) > 8 && Math.abs(totalDy) > Math.abs(totalDx)) {
+        touchState.mode = 'scroll';
+      }
+    }
+
+    if (touchState.mode === 'pan') {
+      const dx = point.x - touchState.lastX;
+      state.viewStart -= dx / state.pxPerYear;
+      touchState.lastX = point.x;
+      touchState.lastY = point.y;
+      draw();
+      event.preventDefault();
+    }
+  }
+
+  function handleTouchEnd(event) {
+    clearTouchLongPress();
+    if (touchState.mode === 'pending' && !touchState.hasMoved && event.changedTouches.length) {
+      const point = getTouchPoint(event.changedTouches[0]);
+      const hit = findEventAtCanvasPoint(point.x, point.y);
+      if (hit) {
+        showEventTooltip(hit.event, point.clientX, point.clientY);
+        event.preventDefault();
+      }
+    }
+    if (event.touches.length === 0) {
+      resetTouchState();
+    } else if (event.touches.length === 1) {
+      const point = getTouchPoint(event.touches[0]);
+      touchState.mode = 'pending';
+      touchState.startX = point.x;
+      touchState.startY = point.y;
+      touchState.lastX = point.x;
+      touchState.lastY = point.y;
+      touchState.hasMoved = false;
+      touchState.layer = findLayerAtCanvasPoint(point.x, point.y);
+    }
+  }
+
+  function handleTouchCancel() {
+    resetTouchState();
+    hideEventTooltip();
   }
 
   function showLayerMenu(x, y, layer) {
@@ -3527,6 +3733,40 @@ const DEFAULT_CSV_SAMPLE = `# time,title（两列；layer 由文件名决定，�
       const text = ui.eventTooltip.textContent || '';
       hideEventTooltip();
       return text.includes('短事件') && text.includes('时间：2000') && !text.includes('图层：');
+    });
+    add('responsive metrics: mobile viewport uses compact pads and touch lanes', () => {
+      const backup = {
+        leftPad: state.leftPad,
+        rightPad: state.rightPad,
+        laneHeight: state.laneHeight,
+      };
+      try {
+        const mobile = isMobileViewport(390);
+        const desktop = isMobileViewport(1024);
+        return mobile && !desktop
+          && MOBILE_LEFT_PAD < DESKTOP_LEFT_PAD
+          && MOBILE_RIGHT_PAD < DESKTOP_RIGHT_PAD
+          && MOBILE_LANE_HEIGHT > DESKTOP_LANE_HEIGHT;
+      } finally {
+        state.leftPad = backup.leftPad;
+        state.rightPad = backup.rightPad;
+        state.laneHeight = backup.laneHeight;
+      }
+    });
+    add('touch helper: layer hit only inside label column', () => {
+      const backup = snapshotState();
+      try {
+        state.data = rowsToEvents(parseCSV('1~2,A', '触摸层'));
+        state.layerOrder = [];
+        rebuildFromState();
+        draw();
+        const box = state.layerRects.get('触摸层');
+        return !!box
+          && findLayerAtCanvasPoint(state.leftPad - 4, box.top + 4) === '触摸层'
+          && findLayerAtCanvasPoint(state.leftPad + 4, box.top + 4) === null;
+      } finally {
+        restoreState(backup);
+      }
     });
     add('toolbar menus: close all except requested menu', () => {
       const menus = Array.from(document.querySelectorAll('.toolbar-menu'));

--- a/styles.css
+++ b/styles.css
@@ -608,3 +608,203 @@ body.side-collapsed .side-drawer::before {
     min-height: 60vh;
   }
 }
+
+@media (hover: none) and (pointer: coarse) {
+  .bar button,
+  .toolbar-menu summary,
+  .menu-file-picker span,
+  .bar select,
+  #layerMenu button,
+  #colorMenu button {
+    min-height: 40px;
+  }
+
+  canvas {
+    touch-action: pan-y;
+  }
+}
+
+@media (max-width: 720px) {
+  body {
+    background: #0b0c10;
+  }
+
+  header {
+    position: sticky;
+  }
+
+  .bar {
+    gap: 8px;
+    padding: 8px;
+  }
+
+  .toolbar-menus {
+    width: 100%;
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 6px;
+  }
+
+  .toolbar-menu {
+    min-width: 0;
+  }
+
+  .toolbar-menu summary {
+    width: 100%;
+    padding: 9px 6px;
+    text-align: center;
+    white-space: nowrap;
+  }
+
+  .toolbar-menu summary::after {
+    margin-left: 4px;
+  }
+
+  .menu-panel,
+  .toolbar-menu-wide .menu-panel {
+    position: fixed;
+    top: calc(var(--mobile-header-height, 106px) + 8px);
+    left: 8px;
+    right: 8px;
+    width: auto;
+    min-width: 0;
+    max-height: min(68vh, 520px);
+    overflow: auto;
+  }
+
+  .zoom-control {
+    order: 2;
+    flex: 1 1 calc(100% - 122px);
+    min-width: 0;
+    padding: 7px 8px;
+    border: 1px solid #1f2a3d;
+    border-radius: 10px;
+    background: rgba(17, 20, 26, 0.72);
+  }
+
+  .zoom-readout {
+    order: 3;
+    flex: 0 0 auto;
+    min-width: 0;
+    font-size: 11px;
+  }
+
+  #btn-reset {
+    order: 4;
+    margin-left: auto;
+    min-height: 40px;
+  }
+
+  .wrap {
+    display: block;
+    min-height: auto;
+  }
+
+  .side {
+    position: fixed;
+    top: var(--mobile-header-height, 106px);
+    left: 0;
+    bottom: 0;
+    z-index: 35;
+    width: min(92vw, 380px);
+    max-width: 100vw;
+    border-right: 1px solid #283349;
+    border-bottom: 0;
+    box-shadow: 18px 0 42px rgba(0, 0, 0, 0.45);
+    transform: translateX(0);
+    transition: transform 160ms ease, opacity 160ms ease;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  body.side-collapsed .wrap {
+    grid-template-columns: 1fr;
+  }
+
+  body.side-collapsed .side {
+    padding: 12px;
+    border-right: 1px solid #283349;
+    overflow: auto;
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateX(calc(-100% - 18px));
+  }
+
+  main {
+    min-height: 72vh;
+  }
+
+  .side-drawer {
+    position: fixed;
+    top: calc(var(--mobile-header-height, 106px) + 14px);
+    width: 42px;
+    height: 60px;
+    z-index: 36;
+    border-radius: 0 16px 16px 0;
+    background: rgba(18, 28, 44, 0.96);
+  }
+
+  .side-drawer::before {
+    line-height: 56px;
+  }
+
+  textarea {
+    height: 190px;
+    font-size: 13px;
+  }
+
+  .hint {
+    max-height: 42vh;
+    overflow: auto;
+  }
+
+  #layerMenu,
+  #colorMenu {
+    width: min(92vw, 300px);
+    padding: 10px;
+  }
+
+  #layerMenu button,
+  #colorMenu button {
+    width: 100%;
+    min-height: 42px;
+    font-size: 14px;
+  }
+
+  #testPanel {
+    left: 8px;
+    right: 8px;
+    bottom: 52px;
+    width: auto;
+  }
+
+  #toast {
+    left: 12px;
+    right: 12px;
+    bottom: 12px;
+    text-align: center;
+  }
+}
+
+@media (max-width: 420px) {
+  .bar {
+    font-size: 12px;
+  }
+
+  .toolbar-menus {
+    gap: 5px;
+  }
+
+  .toolbar-menu summary {
+    font-size: 11px;
+    padding-inline: 4px;
+  }
+
+  .zoom-control span {
+    display: none;
+  }
+
+  .zoom-readout {
+    width: 100%;
+    order: 5;
+  }
+}


### PR DESCRIPTION
### Motivation
- 使时间轴在手机/触控设备上也能良好使用，解决原生鼠标交互在移动端体验差的问题。 
- 优化窄屏下的布局与控件触控面积，避免工具栏与侧栏在小屏被挤压或不可用。 

### Description
- 在 `app.js` 中加入移动端参数与响应式度量：`MOBILE_BREAKPOINT`、左右留白与触控友好 `laneHeight`，并在 `syncCanvasSize` 中根据视窗切换这些度量。 
- 新增触控交互处理器：`handleTouchStart` / `handleTouchMove` / `handleTouchEnd` / `handleTouchCancel`，支持单指横向平移、双指捏合缩放、轻点显示事件气泡与长按展示图层菜单（在 `app.js` 中实现）。 
- 增加对 `visualViewport` 的 resize 监听以改善软键盘/视窗变化时的布局计算（`window.visualViewport?.addEventListener('resize', ...)`）。 
- 在 `styles.css` 中添加移动端样式媒体查询，重排顶部工具栏为网格按钮、将菜单面板改为固定浮层、实现侧栏在手机上作为滑出抽屉并放大触控目标与按钮高度。 
- 扩展内置自测（`runSelfTests`）增加针对移动端度量选择与触控图层命中逻辑的两个测试用例以防回归。 

### Testing
- 运行 `node --check app.js` 验证语法并通过。 
- 执行 `git diff --check` 检查差异没有语法问题并通过。 
- 启动本地 dev server (`npm run dev -- --listen tcp://127.0.0.1:4173`) 并用 `curl -fsSI http://127.0.0.1:4173/` 验证首页返回 `200 OK`，启动与响应验证通过。 
- 尝试安装与运行自动化截图工具 Playwright 用于端到端截图时因当前环境对 npm registry 的访问被拒绝（`403`），因此无法在本次环境中运行浏览器驱动的集成测试。 
- 项目中未配置 `test` 脚本，`npm test` 未运行（提示缺少 `test` script）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a211f765f9c8332b1faeade15c3e0a1)